### PR TITLE

Update README Example Links to plain=1 Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ---
-!-- Timestamp: 2025-02-14 07:07:39
+!-- Timestamp: 2025-02-14 07:15:19
 !-- Author: ywatanabe
 !-- File: /home/ywatanabe/.emacs.d/lisp/emacs-header-footer/README.md
 !-- --- -->
@@ -19,13 +19,13 @@ Automatic header and footer management in Emacs.
 
 ## Supported Files
 
-- [Elisp (.el)](./examples/example.el)
-- [Markdown (.md)](./examples/example.md)
-- [Org (.org)](./examples/example.org)
-- [Python (.py)](./examples/example.py)
-- [Shell (.sh)](./examples/example.sh)
-- [TeX (.tex)](./examples/example.tex)
-- [YAML (.yaml, .yml)](./examples/example.yaml)
+- [Elisp (.el)](./examples/example.el?plain=1)
+- [Markdown (.md)](./examples/example.md?plain=1)
+- [Org (.org)](./examples/example.org?plain=1)
+- [Python (.py)](./examples/example.py?plain=1)
+- [Shell (.sh)](./examples/example.sh?plain=1)
+- [TeX (.tex)](./examples/example.tex?plain=1)
+- [YAML (.yaml, .yml)](./examples/example.yaml?plain=1)
 
 ## Installation
 


### PR DESCRIPTION

- Updated README file to include the plain=1 format in example links.
- Improved the consistency of link formatting throughout the documentation.
- Enhanced readability by streamlining the URL query parameters.
- Standardized documentation examples for better developer experience.
- Refined the presentation of example links for a cleaner layout.
- None
- None